### PR TITLE
Update connect_to_redis_from_url

### DIFF
--- a/RedisLibrary/RedisLibraryKeywords.py
+++ b/RedisLibrary/RedisLibraryKeywords.py
@@ -97,7 +97,7 @@ class RedisLibraryKeywords(object):
         """
         try:
             logger.info("Creating Redis Connection using : url=%s " % redis_url)
-            redis_conn = redis.from_url(redis_url, db)
+            redis_conn = redis.from_url(redis_url, db=db)
         except Exception as ex:
             logger.error(str(ex))
             raise Exception(str(ex))


### PR DESCRIPTION
Seems that since the `from_url` function has signature `def from_url(url, **kwargs):`, we are required to use keyword argument instead of positional argument. Otherwise getting "from_url() takes 1 positional argument but 2 were given" error.