### PR TITLE
feat: specific provider version for avoid force update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: python
 python:
   - "3.9"
-install: "pip install -r requirements.txt"
+install: 
+  - pip install --upgrade pip
+  - pip install -r requirements.txt
+  - pip install urllib3==1.26.15 setuptools==70.0.0 twine==5.1.1  #install package for deploy
 script: make clean test coverage docs dist
 deploy:
   provider: pypi
+  edge:
+    branch: v1.8.45
   user: nottyo
   skip_cleanup: true
   password:


### PR DESCRIPTION
releted from : https://github.com/urllib3/urllib3/issues/2168

When deploying with the default version `provider: pypi`, it forces an upgrade of `twine, setuptools, wheel`, which then affects the upgrade of urllib3, which is not compatible with Python3.9.

I am opening this PR to:
- Specify the PyPI provider version to prevent forced dependency updates
- Add required dependencies with specific versions to support PyPI releases
